### PR TITLE
Add issue selector to pjm fix and MCP record_fix

### DIFF
--- a/src/projectmem/cli.py
+++ b/src/projectmem/cli.py
@@ -106,10 +106,19 @@ def attempt(
 @app.command()
 def fix(
     text: str,
-    at: str | None = typer.Option(None, "--at", help="Location (e.g. file:line, class.method)"),
+    at: str | None = typer.Option(
+        None,
+        "--at",
+        help="Location (e.g. file:line, class.method)",
+    ),
+    issue: str | None = typer.Option(
+        None,
+        "--issue",
+        help="Close a specific issue ID instead of the active issue (e.g. 0042).",
+    ),
 ) -> None:
-    """Record a fix and close the current issue."""
-    fix_command.run(text, location=at)
+    """Record a fix and close the active issue, or a specific issue with --issue."""
+    fix_command.run(text, location=at, issue=issue)
 
 
 @app.command()

--- a/src/projectmem/commands/fix.py
+++ b/src/projectmem/commands/fix.py
@@ -15,14 +15,51 @@ from projectmem.storage import (
 from projectmem.summary import regenerate_summary
 
 
-def run(text: str, location: str | None = None) -> Event:
-    """Close the current issue with a fix. Returns the created fix Event.
+def _normalize_issue_id(issue_id: str | None) -> str | None:
+    """Normalize issue IDs so `1`, `001`, and `0001` all become `0001`."""
+    if issue_id is None:
+        return None
 
-    Clears the current-issue marker so subsequent `pjm attempt` calls do not
-    silently re-attach to the just-closed issue (the L-027a misattribution bug).
+    cleaned = issue_id.strip().lstrip("#")
+    if not cleaned:
+        return None
+    if cleaned.isdigit():
+        return cleaned.zfill(4)
+    return cleaned
+
+
+def _issue_exists(events: list[Event], issue_id: str) -> bool:
+    """Return True if an issue event exists for the requested issue ID."""
+    return any(event.type == "issue" and event.issue_id == issue_id for event in events)
+
+
+def run(
+    text: str,
+    location: str | None = None,
+    issue: str | None = None,
+) -> Event:
+    """Close an issue with a fix. Returns the created fix Event.
+
+    When `issue` is omitted, this preserves the existing behavior:
+    close the current issue and clear the current-issue marker.
+
+    When `issue` is provided, the fix is attached to that specific issue.
+    The current-issue marker is only cleared if it points at the same issue.
     """
     events = read_events()
-    issue_id = read_current_issue() or current_issue_id(events)
+    requested_issue_id = _normalize_issue_id(issue)
+    active_issue_id = read_current_issue() or current_issue_id(events)
+
+    if requested_issue_id is not None:
+        issue_id = requested_issue_id
+        if not _issue_exists(events, issue_id):
+            raise ProjectMemError(
+                f"Issue #{issue_id} was not found. "
+                "Run `pjm search <query>` or `pjm brief` to find the issue ID."
+            )
+    else:
+        issue_id = active_issue_id
+
     if issue_id is None:
         raise ProjectMemError("No open issue found. Run `pjm log <text>` first.")
 
@@ -34,7 +71,12 @@ def run(text: str, location: str | None = None) -> Event:
         location=location,
     )
     append_event(event)
-    clear_current_issue()
+
+    # Preserve old behavior when no specific issue was requested. For targeted
+    # fixes, only clear the active marker if it matches the issue being fixed.
+    if requested_issue_id is None or active_issue_id == issue_id:
+        clear_current_issue()
+
     regenerate_summary()
     typer.echo(f"Fixed issue #{issue_id}")
     return event

--- a/src/projectmem/mcp_server.py
+++ b/src/projectmem/mcp_server.py
@@ -154,7 +154,7 @@ mcp = FastMCP(
         "directly via filesystem write:\n"
         "  - On a bug discovery → log_issue(summary, location).\n"
         "  - After each fix attempt → record_attempt(summary, outcome).\n"
-        "  - After confirmation → record_fix(summary).\n"
+        "  - After confirmation → use record_fix(summary) for the active issue. If fixing a specific older issue, use record_fix(summary, issue_id=\"<issue_id>\") and replace <issue_id> with the actual Projectmem issue ID.\n"
         "  - On a design choice → add_decision(summary).\n"
         "  - On a gotcha / setup detail → add_note(summary).\n"
         "Editing .projectmem/summary.md or .projectmem/PROJECT_MAP.md\n"
@@ -509,26 +509,43 @@ def record_attempt(
 @mcp.tool()
 @safe_tool
 def record_fix(
-    summary: Annotated[str, Field(
-        description="One-line description of the confirmed fix (e.g., "
-                    "'guarded submit handler with isSubmitting ref')."
-    )],
-    location: Annotated[Optional[str], Field(
-        description="Optional file path or component where the fix was "
-                    "applied."
-    )] = None,
+    summary: Annotated[
+        str,
+        Field(
+            description=(
+                "One-line description of the confirmed fix "
+                "(e.g., 'guarded submit handler with isSubmitting ref')."
+            )
+        ),
+    ],
+    location: Annotated[
+        Optional[str],
+        Field(
+            description="Optional file path or component where the fix was applied."
+        ),
+    ] = None,
+    issue_id: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional zero-padded issue ID (e.g., '0042') to close. "
+                "When omitted, closes the active issue. Numeric strings without "
+                "padding are accepted."
+            )
+        ),
+    ] = None,
 ) -> str:
-    """Record a confirmed fix and close the current issue.
+    """Record a confirmed fix and close an issue.
 
-    Only call AFTER you have evidence the fix works (test passes, error
-    gone, user confirmed). Closing the issue clears the active-issue
-    marker so the next record_attempt won't silently latch onto this
-    closed issue (L-027a).
+    Only call AFTER you have evidence the fix works: test passes, error is gone,
+    or the user confirmed.
 
-    Side effects: appends a `fix` event, closes the active issue, and
-    clears the active-issue marker so the next record_attempt won't
-    silently latch onto a closed issue."""
-    event = fix.run(summary, location=location)
+    If `issue_id` is provided, the fix is attached to that specific issue.
+    If `issue_id` is omitted, the active issue is closed.
+
+    Side effects: appends a `fix` event and updates summary.md. The active-issue
+    marker is cleared only when the active issue is the issue being fixed."""
+    event = fix.run(summary, location=location, issue=issue_id)
     return f"Fixed issue #{event.issue_id}: {summary}"
 
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -34,6 +34,92 @@ def test_log_attempt_and_fix_write_events(tmp_path, monkeypatch):
     assert events[1]["outcome"] == "failed"
 
 
+def test_fix_issue_closes_target_without_clearing_newer_active_issue(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    runner.invoke(app, ["init"], catch_exceptions=False)
+    runner.invoke(app, ["log", "old issue"], catch_exceptions=False)
+    runner.invoke(app, ["log", "new issue"], catch_exceptions=False)
+
+    result = runner.invoke(
+        app,
+        ["fix", "fixed old issue", "--issue", "1"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Fixed issue #0001" in result.stdout
+    assert (
+        tmp_path / ".projectmem" / ".current_issue"
+    ).read_text(encoding="utf-8") == "0002"
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / ".projectmem" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[-1]["type"] == "fix"
+    assert events[-1]["issue_id"] == "0001"
+
+
+def test_plain_fix_still_closes_active_issue(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    runner.invoke(app, ["init"], catch_exceptions=False)
+    runner.invoke(app, ["log", "active issue"], catch_exceptions=False)
+
+    result = runner.invoke(app, ["fix", "fixed active"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "Fixed issue #0001" in result.stdout
+    assert not (tmp_path / ".projectmem" / ".current_issue").exists()
+
+
+def test_fix_issue_rejects_unknown_issue(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    runner.invoke(app, ["init"], catch_exceptions=False)
+    runner.invoke(app, ["log", "known issue"], catch_exceptions=False)
+
+    result = runner.invoke(app, ["fix", "missing issue", "--issue", "42"])
+
+    assert result.exit_code == 1
+    assert result.exception is not None
+    assert "Issue #0042 was not found" in str(result.exception)
+
+
+def test_mcp_record_fix_accepts_target_issue_id(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    runner.invoke(app, ["init"], catch_exceptions=False)
+    runner.invoke(app, ["log", "old issue"], catch_exceptions=False)
+    runner.invoke(app, ["log", "new issue"], catch_exceptions=False)
+
+    from projectmem.mcp_server import record_fix
+
+    result = record_fix("fixed old issue through MCP", issue_id="1")
+
+    assert result == "Fixed issue #0001: fixed old issue through MCP"
+    assert (
+        tmp_path / ".projectmem" / ".current_issue"
+    ).read_text(encoding="utf-8") == "0002"
+
+    last = json.loads(
+        (tmp_path / ".projectmem" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()[-1]
+    )
+    assert last["type"] == "fix"
+    assert last["issue_id"] == "0001"
+
+
 def test_attempt_without_open_issue_fails(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     runner = CliRunner()


### PR DESCRIPTION
## Summary

Adds support for closing a specific issue by ID when recording a confirmed fix.

## Why

`pjm attempt` already supports `--issue`, but `pjm fix` only closes the active issue pointer. In real workflows, users may create issue `#0002` before finishing `#0001`. Without an issue selector, a verified fix for `#0001` can be recorded against the wrong active issue or leave `#0001` displayed as open.

Fixes #3

## Changes

- Add optional `issue` parameter to `projectmem.commands.fix.run`.
- Add `pjm fix --issue <id>`.
- Add optional `issue_id` parameter to MCP `record_fix`.
- Normalize numeric issue IDs so `1`, `001`, and `0001` all target `0001`.
- Preserve existing behavior when no issue ID is provided.
- Only clear the active issue marker when fixing the active issue.

## Example

```bash
pjm fix --issue 0001 "resolved MCP artifact leakage in skill/agent workflows"
```

