### PR TITLE
Harden MCP git helpers against stdio hangs

### DIFF
--- a/src/projectmem/commands/context.py
+++ b/src/projectmem/commands/context.py
@@ -422,6 +422,7 @@ def _get_git_status_files(root: Path) -> list[str]:
             capture_output=True,
             text=True,
             timeout=5,
+            stdin=subprocess.DEVNULL,
         )
         files = []
         for line in result.stdout.strip().split("\n"):

--- a/src/projectmem/commands/precheck.py
+++ b/src/projectmem/commands/precheck.py
@@ -486,6 +486,7 @@ def _get_staged_files(root: Path) -> list[str]:
             capture_output=True,
             text=True,
             timeout=5,
+            stdin=subprocess.DEVNULL,
         )
         return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
@@ -506,6 +507,7 @@ def _git_recent_changes(file_path: str, days: int, root: Path | None = None) -> 
             capture_output=True,
             text=True,
             timeout=5,
+            stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
@@ -522,6 +524,7 @@ def _get_working_tree_files(root: Path) -> list[str]:
             capture_output=True,
             text=True,
             timeout=5,
+            stdin=subprocess.DEVNULL,
         )
         return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):

--- a/src/projectmem/staleness.py
+++ b/src/projectmem/staleness.py
@@ -57,6 +57,7 @@ def commits_touching_since(
             capture_output=True,
             text=True,
             timeout=5,
+            stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None

--- a/src/projectmem/storage.py
+++ b/src/projectmem/storage.py
@@ -553,8 +553,10 @@ def get_git_commit(root: Path | None = None) -> str | None:
             check=True,
             capture_output=True,
             text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
         )
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     commit = result.stdout.strip()
     return commit or None

--- a/tests/test_hooks_path.py
+++ b/tests/test_hooks_path.py
@@ -80,12 +80,47 @@ def fake_pjm(tmp_path: Path) -> Path:
     return pjm
 
 
+def _require_launchable_bash() -> str:
+    """Return a bash executable path, or skip when this host cannot run one."""
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is not available")
+
+    try:
+        result = subprocess.run(
+            [bash, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        pytest.skip(f"bash is not launchable: {exc}")
+
+    if result.returncode != 0:
+        reason = _bash_failure_reason(result)
+        pytest.skip(f"bash is not launchable: {reason[:120]}")
+
+    return bash
+
+
+def _bash_failure_reason(result: subprocess.CompletedProcess[str]) -> str:
+    """Normalize Windows bash/WSL startup errors for readable skip messages."""
+    return (
+        ((result.stderr or "") + "\n" + (result.stdout or ""))
+        .replace("\x00", "")
+        .strip()
+    )
+
+
 def test_hook_runs_under_stripped_path(tmp_path: Path, fake_pjm: Path) -> None:
     """Simulate git's non-interactive hook environment: PATH = /usr/bin only.
 
     The hook must still find pjm via the baked absolute path, NOT via
     `command -v`. This is the exact failure mode L-047 fixes.
     """
+    bash = _require_launchable_bash()
+
     # Lay out a repo with .projectmem so the hook's directory check passes.
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -103,16 +138,24 @@ def test_hook_runs_under_stripped_path(tmp_path: Path, fake_pjm: Path) -> None:
         "PATH": "/usr/bin:/bin",
         "HOME": str(tmp_path),
     }
+    # Resolve bash before stripping PATH; the stripped PATH is the condition
+    # being tested inside the hook process.
     result = subprocess.run(
-        ["bash", str(hook)],
+        [bash, str(hook)],
         cwd=repo,
         env=minimal_env,
         capture_output=True,
         text=True,
         timeout=10,
+        stdin=subprocess.DEVNULL,
     )
     log_path = fake_pjm.parent.parent / "pjm.log"
-    assert result.returncode == 0, f"hook errored: {result.stderr}"
+    if result.returncode != 0:
+        reason = _bash_failure_reason(result)
+        lowered = reason.lower()
+        if "wsl" in lowered or "bash/" in lowered:
+            pytest.skip(f"bash is not launchable for hook scripts: {reason[:120]}")
+        assert result.returncode == 0, f"hook errored: {reason}"
     assert log_path.exists(), (
         "hook did not invoke pjm — this is the L-047 regression "
         f"(stripped PATH = {minimal_env['PATH']!r}). stderr: {result.stderr!r}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from projectmem.models import Event
+from projectmem.storage import append_event, initialize
+
+
+def _completed(args: list[str], stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+
+def test_git_helpers_detach_stdin_and_keep_timeouts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from projectmem import storage, staleness
+    from projectmem.commands import context, precheck
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append({"args": args, **kwargs})
+        if args[:2] == ["git", "status"]:
+            return _completed(args, "XY README.md\n")
+        if args[:2] == ["git", "rev-parse"]:
+            return _completed(args, "abc123\n")
+        return _completed(args, "abc msg\n")
+
+    monkeypatch.setattr(storage.subprocess, "run", fake_run)
+    monkeypatch.setattr(staleness.subprocess, "run", fake_run)
+    monkeypatch.setattr(precheck.subprocess, "run", fake_run)
+    monkeypatch.setattr(context.subprocess, "run", fake_run)
+
+    assert storage.get_git_commit(tmp_path) == "abc123"
+    assert (
+        staleness.commits_touching_since(
+            "README.md", "2026-01-01T00:00:00Z", tmp_path
+        )
+        == 1
+    )
+    assert precheck._git_recent_changes("README.md", 30, tmp_path) == 1
+    assert precheck._get_staged_files(tmp_path) == ["abc msg"]
+    assert precheck._get_working_tree_files(tmp_path) == ["abc msg"]
+    assert context._get_git_status_files(tmp_path) == ["README.md"]
+
+    assert calls
+    assert all(call.get("stdin") is subprocess.DEVNULL for call in calls)
+    assert all(call.get("timeout") == 5 for call in calls)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _make_git_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "t@t.test")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("# demo\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    initialize(repo)
+    return repo
+
+
+def _mcp_env(repo_root: Path, tmp_path: Path) -> dict[str, str]:
+    src_path = str(repo_root / "src")
+    existing = os.environ.get("PYTHONPATH")
+    return {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "PYTHONPATH": src_path if not existing else src_path + os.pathsep + existing,
+    }
+
+
+def _call_mcp_tool(
+    project: Path,
+    tmp_path: Path,
+    name: str,
+    arguments: dict[str, Any],
+    timeout: float = 6.0,
+) -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[1]
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "projectmem.mcp_server", "--root", str(project)],
+        cwd=project,
+        env=_mcp_env(repo_root, tmp_path),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    stdout_q: queue.Queue[str] = queue.Queue()
+
+    def pump_stdout() -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            stdout_q.put(line.rstrip("\n"))
+
+    thread = threading.Thread(target=pump_stdout, daemon=True)
+    thread.start()
+
+    def send(message: dict[str, Any]) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(message) + "\n")
+        proc.stdin.flush()
+
+    def read_response(
+        message_id: int, wait_seconds: float
+    ) -> dict[str, Any] | None:
+        deadline = time.time() + wait_seconds
+        while time.time() < deadline:
+            try:
+                line = stdout_q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if payload.get("id") == message_id:
+                return payload
+        return None
+
+    try:
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "projectmem-test", "version": "0"},
+                },
+            }
+        )
+        initialized = read_response(1, timeout)
+        assert initialized is not None
+        send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = read_response(2, timeout)
+        if response is None:
+            pytest.fail(f"MCP tool {name} did not respond within {timeout}s")
+        return response
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def _tool_text(response: dict[str, Any]) -> str:
+    content = response["result"]["content"]
+    return "\n".join(item.get("text", "") for item in content)
+
+
+def test_mcp_stdio_precheck_file_returns_with_git_backed_analysis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _make_git_project(tmp_path, monkeypatch)
+    append_event(
+        Event(
+            type="note",
+            summary="README precheck regression fixture",
+            location="README.md",
+        ),
+        project,
+    )
+
+    response = _call_mcp_tool(
+        project,
+        tmp_path,
+        "precheck_file",
+        {"file_path": "README.md"},
+    )
+
+    assert response["result"]["isError"] is False
+    assert "README.md" in _tool_text(response)
+
+
+def test_mcp_stdio_add_note_returns_and_writes_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _make_git_project(tmp_path, monkeypatch)
+
+    response = _call_mcp_tool(
+        project,
+        tmp_path,
+        "add_note",
+        {"summary": "MCP smoke note from pytest"},
+    )
+
+    assert response["result"]["isError"] is False
+    assert "Recorded note" in _tool_text(response)
+    events_text = (project / ".projectmem" / "events.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert "MCP smoke note from pytest" in events_text

--- a/tests/test_v014_features.py
+++ b/tests/test_v014_features.py
@@ -39,7 +39,12 @@ def _event_ids(tmp_path) -> list[str]:
 
 def _git(tmp_path, *args):
     subprocess.run(
-        ["git", *args], cwd=tmp_path, check=True, capture_output=True, text=True
+        ["git", *args],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
     )
 
 


### PR DESCRIPTION
## Summary

- Harden MCP-reachable git helper calls so subprocesses do not inherit the MCP server’s JSON-RPC stdin pipe.
- Add timeouts around git commit lookup paths used by write operations like `add_note` and `record_fix`.
- Preserve CLI behavior while making MCP stdio clients less likely to hang on Windows.

## Root Cause

Some MCP tool paths spawned git subprocesses with inherited stdin. In stdio-based MCP sessions, that stdin is also the JSON-RPC transport, so child processes could block or interfere with the MCP server even when the same command returned normally from the CLI.

## Validation

- Added MCP stdio regression coverage for `precheck_file` and `add_note`.
- Added focused subprocess tests for MCP-reachable git helper calls.
- Confirmed CLI-facing behavior remains unchanged.