### PR TITLE
fix: make console output encoding-safe

### DIFF
--- a/src/projectmem/commands/brief.py
+++ b/src/projectmem/commands/brief.py
@@ -8,6 +8,7 @@ no daemon, nothing leaves the machine.
 """
 from __future__ import annotations
 
+import sys
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -31,13 +32,40 @@ _GREEN = "\033[32m"
 _RESET = "\033[0m"
 
 
+def _stdout_encoding() -> str:
+    """Return the active stdout encoding, falling back to UTF-8."""
+    return getattr(sys.stdout, "encoding", None) or "utf-8"
+
+
+def _console_safe(text: object) -> str:
+    """Return text that can be printed by the current console encoding."""
+    value = str(text)
+    encoding = _stdout_encoding()
+    try:
+        value.encode(encoding)
+        return value
+    except UnicodeEncodeError:
+        return value.encode(encoding, errors="replace").decode(encoding)
+
+
+def _safe_echo(text: object = "") -> None:
+    typer.echo(_console_safe(text))
+
+
+def _rule(width: int = 60) -> str:
+    encoding = _stdout_encoding().lower()
+    if "utf" in encoding:
+        return "─" * width
+    return "-" * width
+
+
 def run(root: Path | None = None) -> None:
     root_path = root or Path.cwd()
     events = read_events(root)
 
-    typer.echo("")
-    typer.echo(f"{_BOLD}projectmem brief — {root_path.name}{_RESET}")
-    typer.echo(f"{_DIM}{'─' * 60}{_RESET}")
+    _safe_echo("")
+    _safe_echo(f"{_BOLD}projectmem brief — {root_path.name}{_RESET}")
+    _safe_echo(f"{_DIM}{_rule(60)}{_RESET}")
 
     _section_warnings(events)
     _section_stale(events, root_path)
@@ -46,8 +74,8 @@ def run(root: Path | None = None) -> None:
     _section_gotchas(root_path)
     _section_score(events)
 
-    typer.echo(f"{_DIM}{'─' * 60}{_RESET}")
-    typer.echo("")
+    _safe_echo(f"{_DIM}{_rule(60)}{_RESET}")
+    _safe_echo("")
 
 
 def _recent(events: list[Event], days: int = RECENT_DAYS) -> list[Event]:
@@ -79,13 +107,13 @@ def _section_warnings(events: list[Event]) -> None:
     by_file: dict[str, list[Event]] = defaultdict(list)
     for e in failed:
         by_file[_file_of(e) or "(no file)"].append(e)
-    typer.echo(f"{_YELLOW}⚠ Active warnings{_RESET}")
+    _safe_echo(f"{_YELLOW}⚠ Active warnings{_RESET}")
     if not by_file:
-        typer.echo(f"   {_DIM}none — no failed attempts in {RECENT_DAYS} days{_RESET}")
+        _safe_echo(f"   {_DIM}none — no failed attempts in {RECENT_DAYS} days{_RESET}")
         return
     for file_path, items in sorted(by_file.items(), key=lambda kv: -len(kv[1]))[:4]:
         last = items[-1]
-        typer.echo(
+        _safe_echo(
             f"   {file_path} — {len(items)} failed attempt"
             f"{'s' if len(items) != 1 else ''} "
             f"{_DIM}(last: {last.summary[:60]}){_RESET}"
@@ -101,18 +129,18 @@ def _section_stale(events: list[Event], root: Path) -> None:
         stale = []
     if not stale:
         return  # silence is the right default — no flags, no noise
-    typer.echo(f"{_YELLOW}⏳ Possibly stale{_RESET}")
+    _safe_echo(f"{_YELLOW}⏳ Possibly stale{_RESET}")
     for item in stale[:MAX_STALE]:
         event = item["event"]
         if item["commits_since"] == -1:
             reason = f"{item['file']} no longer exists"
         else:
             reason = f"{item['file']} changed {item['commits_since']}x since"
-        typer.echo(
+        _safe_echo(
             f"   {event.type} [{event.id}] {event.summary[:55]} "
             f"{_DIM}— {reason}{_RESET}"
         )
-    typer.echo(
+    _safe_echo(
         f"   {_DIM}confirm, or retire: pjm decision \"...\" --supersedes <id>{_RESET}"
     )
 
@@ -122,12 +150,12 @@ def _section_open_issues(events: list[Event]) -> None:
     open_issues = [
         e for e in events if e.type == "issue" and e.issue_id not in fixed
     ]
-    typer.echo(f"{_RED}📋 Open issues{_RESET}")
+    _safe_echo(f"{_RED}📋 Open issues{_RESET}")
     if not open_issues:
-        typer.echo(f"   {_DIM}none open{_RESET}")
+        _safe_echo(f"   {_DIM}none open{_RESET}")
         return
     for issue in open_issues[-4:]:
-        typer.echo(f"   #{issue.issue_id} {issue.summary[:70]}")
+        _safe_echo(f"   #{issue.issue_id} {issue.summary[:70]}")
 
 
 def _section_decisions(events: list[Event]) -> None:
@@ -135,12 +163,12 @@ def _section_decisions(events: list[Event]) -> None:
     live = [
         e for e in events if e.type == "decision" and e.id not in retired
     ]
-    typer.echo(f"{_TEAL}🕑 Recent decisions{_RESET}")
+    _safe_echo(f"{_TEAL}🕑 Recent decisions{_RESET}")
     if not live:
-        typer.echo(f"   {_DIM}none logged yet{_RESET}")
+        _safe_echo(f"   {_DIM}none logged yet{_RESET}")
         return
     for d in live[-MAX_DECISIONS:]:
-        typer.echo(f"   {d.summary[:75]}")
+        _safe_echo(f"   {d.summary[:75]}")
 
 
 def _section_gotchas(root: Path) -> None:
@@ -153,11 +181,11 @@ def _section_gotchas(root: Path) -> None:
         gotchas = []
     if not gotchas:
         return
-    typer.echo(f"{_TEAL}💡 Stack gotchas{_RESET}")
+    _safe_echo(f"{_TEAL}💡 Stack gotchas{_RESET}")
     for g in gotchas[-MAX_GOTCHAS:]:
         lib = g.get("library", "")
         text = g.get("text") or g.get("summary") or ""
-        typer.echo(f"   {lib}: {text[:70]}")
+        _safe_echo(f"   {lib}: {text[:70]}")
 
 
 def _section_score(events: list[Event]) -> None:
@@ -187,6 +215,6 @@ def _section_score(events: list[Event]) -> None:
         trend = f" {_RED}▼ {delta} this week{_RESET}"
     else:
         trend = f" {_DIM}— unchanged this week{_RESET}"
-    typer.echo(
+    _safe_echo(
         f"{_GREEN}📈 Score{_RESET}  {current['grade']} ({current['score']}/100){trend}"
     )

--- a/src/projectmem/commands/precheck.py
+++ b/src/projectmem/commands/precheck.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from collections import defaultdict
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -50,6 +51,33 @@ SEVERITY_LEVELS = {SEVERITY_INFO: 0, SEVERITY_WARN: 1, SEVERITY_BLOCK: 2}
 SNOOZE_MARKER = "precheck.snooze"
 _DURATION_RE = re.compile(r"^(\d+)\s*([mhd])$", re.IGNORECASE)
 _DURATION_UNITS = {"m": "minutes", "h": "hours", "d": "days"}
+
+
+def _stdout_encoding() -> str:
+    """Return the active stdout encoding, falling back to UTF-8."""
+    return getattr(sys.stdout, "encoding", None) or "utf-8"
+
+
+def _console_safe(text: object) -> str:
+    """Return text that can be printed by the current console encoding."""
+    value = str(text)
+    encoding = _stdout_encoding()
+    try:
+        value.encode(encoding)
+        return value
+    except UnicodeEncodeError:
+        return value.encode(encoding, errors="replace").decode(encoding)
+
+
+def _safe_echo(text: object = "", *, err: bool = False) -> None:
+    typer.echo(_console_safe(text), err=err)
+
+
+def _rule(width: int = 60) -> str:
+    encoding = _stdout_encoding().lower()
+    if "utf" in encoding:
+        return "─" * width
+    return "-" * width
 
 
 def parse_snooze_duration(text: str) -> timedelta:
@@ -150,17 +178,17 @@ def run(
     # Snooze management actions short-circuit the check itself.
     if unsnooze:
         if clear_snooze(root):
-            typer.echo("projectmem: precheck warnings re-enabled.")
+            _safe_echo("projectmem: precheck warnings re-enabled.")
         else:
-            typer.echo("projectmem: no active snooze.")
+            _safe_echo("projectmem: no active snooze.")
         return
     if snooze:
         try:
             expiry = set_snooze(snooze, root)
         except ValueError as exc:
-            typer.echo(f"Error: {exc}", err=True)
+            _safe_echo(f"Error: {exc}", err=True)
             raise typer.Exit(1)
-        typer.echo(
+        _safe_echo(
             f"projectmem: precheck warnings snoozed until "
             f"{expiry.strftime('%H:%M UTC')} (logged to memory). "
             f"Re-enable early with `pjm precheck --unsnooze`."
@@ -171,7 +199,7 @@ def run(
     # silenced warning is never mistaken for a clean check.
     expiry = active_snooze(root)
     if expiry is not None:
-        typer.echo(
+        _safe_echo(
             f"\033[2mprojectmem: warnings snoozed ({_remaining(expiry)} left) — "
             f"`pjm precheck --unsnooze` to re-enable.\033[0m"
         )
@@ -187,7 +215,7 @@ def run(
 
     if not target_files:
         if not quiet:
-            typer.echo("projectmem: No files to check.")
+            _safe_echo("projectmem: No files to check.")
         return
 
     # Read events and build warnings
@@ -200,7 +228,7 @@ def run(
 
     if not warnings:
         if not quiet:
-            typer.echo("\033[32mprojectmem:\033[0m no warnings — looking good!")
+            _safe_echo("\033[32mprojectmem:\033[0m no warnings — looking good!")
         return
 
     # Render warnings
@@ -264,7 +292,7 @@ def _analyze_files(
             details = []
             for attempt in reversed(failed_attempts[-3:]):
                 details.append(
-                    f"✗ {attempt.summary[:90]} ({_age(attempt.timestamp)})"
+                    f"x {attempt.summary[:90]} ({_age(attempt.timestamp)})"
                 )
             if count > 3:
                 details.append(f"  ... and {count - 3} more (pjm search --failed-only)")
@@ -437,10 +465,10 @@ def _render_warnings(warnings: list[dict[str, Any]], level: str) -> None:
     if not visible:
         return
 
-    typer.echo("")
-    typer.echo(f"{bold}projectmem: Pre-Commit Check{reset}")
-    typer.echo(f"{dim}{'─' * 60}{reset}")
-    typer.echo("")
+    _safe_echo("")
+    _safe_echo(f"{bold}projectmem: Pre-Commit Check{reset}")
+    _safe_echo(f"{dim}{_rule(60)}{reset}")
+    _safe_echo("")
 
     # Group by file
     by_file: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -448,7 +476,7 @@ def _render_warnings(warnings: list[dict[str, Any]], level: str) -> None:
         by_file[w["file"]].append(w)
 
     for file_path, file_warnings in by_file.items():
-        typer.echo(f"  {bold}{file_path}{reset}")
+        _safe_echo(f"  {bold}{file_path}{reset}")
         for w in file_warnings:
             if w["severity"] == SEVERITY_BLOCK:
                 icon = f"{red}BLOCK{reset}"
@@ -456,24 +484,24 @@ def _render_warnings(warnings: list[dict[str, Any]], level: str) -> None:
                 icon = f"{yellow}WARN{reset}"
             else:
                 icon = f"{cyan}INFO{reset}"
-            typer.echo(f"    {icon}  {w['title']}")
+            _safe_echo(f"    {icon}  {w['title']}")
             for detail in w["details"]:
-                typer.echo(f"           {dim}{detail}{reset}")
-        typer.echo("")
+                _safe_echo(f"           {dim}{detail}{reset}")
+        _safe_echo("")
 
-    typer.echo(f"{dim}{'─' * 60}{reset}")
+    _safe_echo(f"{dim}{_rule(60)}{reset}")
 
     blocking = sum(1 for w in visible if w["severity"] == SEVERITY_BLOCK)
     warning = sum(1 for w in visible if w["severity"] == SEVERITY_WARN)
 
     if blocking and level == SEVERITY_BLOCK:
-        typer.echo(f"{red}Blocked: {blocking} critical warning(s).{reset}")
-        typer.echo(f"  Bypass once: git commit --no-verify")
+        _safe_echo(f"{red}Blocked: {blocking} critical warning(s).{reset}")
+        _safe_echo("  Bypass once: git commit --no-verify")
     elif warning or blocking:
-        typer.echo(
+        _safe_echo(
             f"{dim}{warning + blocking} warning(s). Review before committing.{reset}"
         )
-    typer.echo("")
+    _safe_echo("")
 
 
 def _get_staged_files(root: Path) -> list[str]:

--- a/tests/test_v014_features.py
+++ b/tests/test_v014_features.py
@@ -275,6 +275,19 @@ def test_brief_runs_clean_on_fresh_project(tmp_path, monkeypatch):
     assert "none" in result.output  # empty sections degrade gracefully
 
 
+def test_brief_console_helpers_are_cp1252_safe(monkeypatch):
+    from projectmem.commands import brief
+
+    class Cp1252Stdout:
+        encoding = "cp1252"
+
+    monkeypatch.setattr(brief.sys, "stdout", Cp1252Stdout())
+
+    assert brief._rule() == "-" * 60
+    text = brief._console_safe("⚠ ─ projectmem brief — projectmem 📈")
+    text.encode("cp1252")
+
+
 # ── 5. Failed-approach surfacing ─────────────────────────────────────
 
 
@@ -294,6 +307,19 @@ def test_precheck_lists_failed_approaches():
     assert "What already failed here" in failed[0]["title"]
     assert "tried CSS contain:layout" in details
     assert "debounced the handler" in details
+
+
+def test_precheck_console_helpers_are_cp1252_safe(monkeypatch):
+    from projectmem.commands import precheck
+
+    class Cp1252Stdout:
+        encoding = "cp1252"
+
+    monkeypatch.setattr(precheck.sys, "stdout", Cp1252Stdout())
+
+    assert precheck._rule() == "-" * 60
+    text = precheck._console_safe("✗ ─ warning ⚠")
+    text.encode("cp1252")
 
 
 def test_precheck_named_files_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Make `pjm brief` output safe on non-UTF-8 Windows consoles.
- Make `pjm precheck` rendering safe for CP1252 consoles, including separators and failed-attempt markers.
- Keep this separate from MCP/git subprocess hardening in #4.

## Tests

- `python -m pytest tests\test_v014_features.py::test_brief_console_helpers_are_cp1252_safe tests\test_v014_features.py::test_precheck_console_helpers_are_cp1252_safe -q`
- `python -m pytest tests\test_v014_features.py -q`
- `python -m compileall -q src tests`

## Notes

This PR intentionally excludes version bumps, release notes, `.gitignore`, MCP stdio changes, and git subprocess hardening. Full-suite green depends on #4.