### PR TITLE
fix(watch): replace os.fork daemon with detached subprocess worker for Windows support

### DIFF
--- a/src/projectmem/cli.py
+++ b/src/projectmem/cli.py
@@ -381,9 +381,10 @@ def watch(
     daemon: bool = typer.Option(False, "--daemon", help="Run in background as a daemon."),
     stop: bool = typer.Option(False, "--stop", help="Stop the running watcher."),
     status: bool = typer.Option(False, "--status", help="Show watcher status."),
+    worker: bool = typer.Option(False, "--worker", hidden=True, help="Internal background worker."),
 ) -> None:
     """Watch file activity in real-time and log churn events (opt-in)."""
-    watch_command.run(daemon=daemon, stop=stop, status=status)
+    watch_command.run(daemon=daemon, stop=stop, status=status, worker=worker)
 
 
 @app.command()

--- a/src/projectmem/commands/watch.py
+++ b/src/projectmem/commands/watch.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import signal
+import subprocess
 import sys
 import time
 from collections import defaultdict, deque
@@ -132,6 +133,7 @@ def run(
     daemon: bool = False,
     stop: bool = False,
     status: bool = False,
+    worker: bool = False,
     root: Path | None = None,
 ) -> None:
     """Dispatch watch subcommands."""
@@ -142,6 +144,9 @@ def run(
         return
     if status:
         _show_status(root)
+        return
+    if worker:
+        _run_worker(root)
         return
 
     # Check for existing daemon
@@ -172,44 +177,9 @@ def _run_foreground(root: Path | None = None) -> None:
         _cleanup_pid_file(root)
 
 
-def _run_as_daemon(root: Path | None = None) -> None:
-    """Fork to background and run watch loop."""
-    # Fork once and detach
-    try:
-        pid = os.fork()
-    except OSError as e:
-        typer.echo(f"\033[31mprojectmem:\033[0m Daemon fork failed: {e}", err=True)
-        return
-
-    if pid > 0:
-        # Parent — report success and exit
-        time.sleep(0.3)  # give child time to write PID
-        new_pid = _running_pid(root)
-        if new_pid:
-            typer.echo(
-                f"\033[32mprojectmem:\033[0m Watcher started (PID {new_pid})\n"
-                f"  Logs: .projectmem/watch.log\n"
-                f"  Stop: pjm watch --stop"
-            )
-        else:
-            typer.echo(
-                "\033[33mprojectmem:\033[0m Daemon may have failed to start — check .projectmem/watch.log"
-            )
-        return
-
-    # Child — detach and run
-    os.setsid()
-    # Redirect stdio to watch.log
+def _run_worker(root: Path | None = None) -> None:
+    """Run watch loop as background worker."""
     root_path = root or Path.cwd()
-    log_file = _log_path(root_path)
-    try:
-        log_fd = open(log_file, "a", encoding="utf-8")
-        os.dup2(log_fd.fileno(), sys.stdout.fileno())
-        os.dup2(log_fd.fileno(), sys.stderr.fileno())
-        sys.stdin = open(os.devnull, "r")
-    except OSError:
-        pass
-
     _write_pid(os.getpid(), root_path)
 
     # Register signal handlers
@@ -218,13 +188,82 @@ def _run_as_daemon(root: Path | None = None) -> None:
         _cleanup_pid_file(root_path)
         sys.exit(0)
 
-    signal.signal(signal.SIGTERM, _shutdown)
-    signal.signal(signal.SIGINT, _shutdown)
+    try:
+        signal.signal(signal.SIGTERM, _shutdown)
+    except (ValueError, AttributeError):
+        pass
+    try:
+        signal.signal(signal.SIGINT, _shutdown)
+    except (ValueError, AttributeError):
+        pass
 
     try:
         _watch_loop(root_path, verbose=False)
     finally:
         _cleanup_pid_file(root_path)
+
+
+def _run_as_daemon(root: Path | None = None) -> None:
+    """Spawn detached background process and run watch loop."""
+    root_path = (root or Path.cwd()).resolve()
+    log_file = _log_path(root_path)
+
+    try:
+        log_fd = open(log_file, "a", encoding="utf-8")
+    except OSError as e:
+        typer.echo(f"\033[31mprojectmem:\033[0m Cannot open log file: {e}", err=True)
+        return
+
+    cmd = [sys.executable, "-m", "projectmem.cli", "watch", "--worker"]
+
+    try:
+        if sys.platform.startswith("win"):
+            flags = (
+                subprocess.DETACHED_PROCESS
+                | subprocess.CREATE_NEW_PROCESS_GROUP
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+            )
+            proc = subprocess.Popen(
+                cmd,
+                cwd=str(root_path),
+                stdin=subprocess.DEVNULL,
+                stdout=log_fd,
+                stderr=log_fd,
+                creationflags=flags,
+                close_fds=True,
+            )
+        else:
+            proc = subprocess.Popen(
+                cmd,
+                cwd=str(root_path),
+                stdin=subprocess.DEVNULL,
+                stdout=log_fd,
+                stderr=log_fd,
+                start_new_session=True,
+                close_fds=True,
+            )
+    except OSError as e:
+        typer.echo(f"\033[31mprojectmem:\033[0m Daemon spawn failed: {e}", err=True)
+        return
+    finally:
+        log_fd.close()
+
+    # Give child a moment to write PID and initialize
+    time.sleep(0.3)
+    if proc.poll() is not None:
+        typer.echo(
+            f"\033[31mprojectmem:\033[0m Daemon exited unexpectedly (code {proc.returncode}) — check .projectmem/watch.log",
+            err=True,
+        )
+        return
+
+    new_pid = _running_pid(root_path) or proc.pid
+    _write_pid(new_pid, root_path)
+    typer.echo(
+        f"\033[32mprojectmem:\033[0m Watcher started (PID {new_pid})\n"
+        f"  Logs: .projectmem/watch.log\n"
+        f"  Stop: pjm watch --stop"
+    )
 
 
 def _write_pid(pid: int, root: Path | None = None) -> None:
@@ -370,6 +409,7 @@ def _stop_daemon(root: Path | None = None) -> None:
             time.sleep(0.2)
             if _running_pid(root) is None:
                 break
+        _cleanup_pid_file(root)
         typer.echo(f"\033[32mprojectmem:\033[0m Watcher stopped (PID {pid}).")
     except ProcessLookupError:
         _cleanup_pid_file(root)

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from projectmem.cli import app
+
+
+def test_watch_status_not_running(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(app, ["init", "--no-watch"], catch_exceptions=False)
+
+    result = runner.invoke(app, ["watch", "--status"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "not running" in result.stdout
+
+
+def test_watch_stop_not_running(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(app, ["init", "--no-watch"], catch_exceptions=False)
+
+    result = runner.invoke(app, ["watch", "--stop"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "No watcher running" in result.stdout
+
+
+def test_watch_daemon_spawns_subprocess(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(app, ["init", "--no-watch"], catch_exceptions=False)
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 4242
+    fake_proc.poll.return_value = None
+
+    with patch("subprocess.Popen", return_value=fake_proc) as mock_popen, \
+         patch("time.sleep"):
+        result = runner.invoke(app, ["watch", "--daemon"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Watcher started" in result.stdout
+        assert mock_popen.called
+        cmd = mock_popen.call_args[0][0]
+        assert "watch" in cmd
+        assert "--worker" in cmd
+        pid_file = tmp_path / ".projectmem" / "watch.pid"
+        assert pid_file.is_file()
+        assert pid_file.read_text(encoding="utf-8").strip() == "4242"


### PR DESCRIPTION
## Summary

Fixes https://github.com/riponcm/projectmem/issues/12.

Fixes a crash when running `pjm watch --daemon` on Windows by replacing POSIX-specific `os.fork()` / `os.setsid()` daemonization with a cross-platform detached `subprocess.Popen` worker.

## Root Cause

`src/projectmem/commands/watch.py` previously used Unix-specific system calls (`os.fork()`, `os.setsid()`, and file descriptor redirection via `os.dup2`). Because Windows does not implement `fork(2)`, executing `pjm watch --daemon` failed immediately with:
```text
AttributeError: module 'os' has no attribute 'fork'
```
Furthermore, `pjm init`'s automatic background watcher check silently failed on Windows due to the same uncaught `AttributeError`.

## Changes

- **Cross-platform daemonization**: Refactored `_run_as_daemon()` in `src/projectmem/commands/watch.py` to spawn a detached background worker process via `subprocess.Popen`:
  - **Windows**: Launches with `DETACHED_PROCESS`, `CREATE_NEW_PROCESS_GROUP`, and `CREATE_NO_WINDOW` flags to run invisibly without a console window.
  - **POSIX / macOS**: Launches with `start_new_session=True` (clean fork+exec without thread-safety or CoreFoundation lock hazards).
- **Worker command & CLI option**: Added an internal hidden `--worker` option to `pjm watch` (`src/projectmem/cli.py`) and implemented `_run_worker()` in `watch.py` to execute the watch loop, handle signals, and maintain single-instance PID tracking.
- **Stopping cleanup**: Enhanced `_stop_daemon()` to guarantee cleanup of `.projectmem/watch.pid` when the process is terminated on Windows.
- **Test coverage**: Added `tests/test_watch.py` covering `pjm watch --status`, `pjm watch --stop`, and detached daemon subprocess spawning without `os.fork`.

## Compatibility & Zero-Dependency Promise

- **No new dependencies**: Relies entirely on Python standard library modules (`subprocess`, `sys`, `signal`, `pathlib`).
- **POSIX parity**: Existing Linux/macOS behavior is preserved and benefits from safe process detachment without `os.fork` thread deprecations.
- **Local isolation**: State remains strictly within the target repository's `.projectmem/` (`watch.pid`, `watch.log`, and `events.jsonl`).

## Validation

- `uv run --extra dev pytest tests/test_watch.py -v`: **3 passed in 0.22s**
- Manual testing on Windows 11 PowerShell:
  - `pjm watch --daemon` starts cleanly in background and logs PID.
  - `pjm watch --status` reports running status and uptime.
  - `pjm watch --stop` cleanly terminates process and removes PID file.

## Note on Pre-Existing Windows Test Fixtures

Running the full test suite on Windows surfaces 5 pre-existing test fixture failures (`tests/test_init_ux.py` and `tests/test_global_mcp.py`). These failures are independent of this PR and are caused by test fixtures mocking `$HOME` (which Windows `Path.home()` ignores in favor of `%USERPROFILE%` / `%APPDATA%`) and asserting unescaped backslashes in serialized JSON config.

To keep this PR minimal and strictly focused on resolving the watcher daemon crash (#12), those test fixture adjustments are intentionally excluded.

---

**AI & Tooling Disclosure**
- IDE / Agent: Antigravity IDE
- Model: Gemini 3.8 Flash